### PR TITLE
Update dnsmasq_sniproxy.sh

### DIFF
--- a/dnsmasq_sniproxy.sh
+++ b/dnsmasq_sniproxy.sh
@@ -317,7 +317,7 @@ install_sniproxy(){
                 sed -i "s/\%configure CFLAGS\=\"-I\/usr\/include\/libev\"/\%configure CFLAGS\=\"-fPIC -I\/usr\/include\/libev\"/" redhat/sniproxy.spec
                 rpmbuild --define "_sourcedir `pwd`" --define "_topdir /tmp/sniproxy/rpmbuild" --define "debug_package %{nil}" -ba redhat/sniproxy.spec
             fi
-            error_detect_depends "yum -y install /tmp/sniproxy/rpmbuild/RPMS/x86_64/sniproxy-*.rpm"
+            error_detect_depends "yum -y install /tmp/sniproxy/rpmbuild/RPMS/aarch64/sniproxy-*.rpm"
         fi
         download /etc/init.d/sniproxy https://raw.githubusercontent.com/dlundquist/sniproxy/master/redhat/sniproxy.init && chmod +x /etc/init.d/sniproxy
     elif check_sys packageManager apt; then


### PR DESCRIPTION
针对甲骨文VPS，镜像文件为Oracle Linux，Shape为VM.Standard.A1.Flex的服务器进行修正